### PR TITLE
Enable use pf http_archive in cpp_proto_repositories

### DIFF
--- a/cpp/rules.bzl
+++ b/cpp/rules.bzl
@@ -1,6 +1,7 @@
 load("//protobuf:rules.bzl", "proto_compile", "proto_repositories")
 load("//cpp:deps.bzl", "DEPS")
 load("//cpp:grpc_archive.bzl", "grpc_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def cpp_proto_repositories(
     lang_deps = DEPS,
@@ -25,6 +26,8 @@ def cpp_proto_repositories(
     rule = dep.pop("rule")
     if "grpc_archive" == rule:
       grpc_archive(**dep)
+    elif "http_archive" == rule:
+      http_archive(**dep)
     else:
       fail("Unknown loading rule %s for %s" % (rule, dep))
 


### PR DESCRIPTION
With newer versions of Bazel (above 0.22.0) http_archive needs to be supported (i.e., grpc cannot build with Bazel 0.23.x due to this limitation)